### PR TITLE
Add update_url to manifest-example.json to prevent errors with Google…

### DIFF
--- a/manifest-example.json
+++ b/manifest-example.json
@@ -3,6 +3,7 @@
   "name": "ZR GitHub",
   "description": "Adds GitHub capabilities to the ZR website",
   "version": "0.1.0",
+  "update_url": "www.updateurl.com",
   "background": {
     "scripts": [
       "event.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,11 @@
   "requires": true,
   "dependencies": {
     "ace-diff": {
-      "version": "github:benkeen/ace-diff#b2f1833700f78392434cff23771eacc4174832c6"
+      "version": "github:benkeen/ace-diff#666d83b3fe6f565fba7b06f39f5645806104949d",
+      "requires": {
+        "diff-match-patch": "1.0.0",
+        "lodash": "4.17.4"
+      }
     },
     "acorn": {
       "version": "5.1.2",
@@ -1723,6 +1727,11 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg="
     },
     "diffie-hellman": {
       "version": "5.0.2",

--- a/popup/src/scripts/components/ace-diff/Diff.jsx
+++ b/popup/src/scripts/components/ace-diff/Diff.jsx
@@ -44,6 +44,8 @@ class Diff extends Component {
   }
 
   render () {
+    console.log(this.state)
+    console.log(this.props.placeholder)
     return (
       <div>
         {this.props.diffing
@@ -62,7 +64,8 @@ class Diff extends Component {
                   <span> with branch </span>
                   <div style={{flexGrow: '1'}}>
                     <BranchList value={this.state.base} branches={this.props.branches}
-                      updateFunc={(base) => { this.setState({base}) }} />
+                      placeholder={this.props.placeholder}
+		      updateFunc={(base) => { this.setState({base}) }} />
                   </div>
                   <div><input type='submit' value='start diff' /></div>
                 </div>

--- a/popup/src/scripts/components/app/App.jsx
+++ b/popup/src/scripts/components/app/App.jsx
@@ -282,7 +282,7 @@ class App extends Component {
             this.setState({mergeInProgress: !this.state.mergeInProgress})
           }}
           branches={this.state.branches} />
-        <Diff branches={this.state.branches} path={this.main}
+        <Diff placeholder={this.state.branch} branches={this.state.branches} path={this.main}
           diffing={this.state.diffing}
           updateDiffing={this.updateDiffing}
         />

--- a/popup/src/scripts/components/branches/BranchSwitcher.jsx
+++ b/popup/src/scripts/components/branches/BranchSwitcher.jsx
@@ -73,7 +73,7 @@ class BranchList extends Component {
                 promptTextCreator={this.props.promptTextCreator} />
               : <Select
                 options={options} value={value}
-                clearable={false}
+                clearable={false} placeholder = {this.props.placeholder}
                 disabled={this.props.disabled}
                 onChange={onChange} />}
           </div>}

--- a/popup/src/scripts/components/branches/BranchSwitcher.jsx
+++ b/popup/src/scripts/components/branches/BranchSwitcher.jsx
@@ -54,6 +54,7 @@ class BranchList extends Component {
     const onChange = (change) => { this.props.updateFunc(change.value) }
     const value = this.props.value && {label: this.props.value, value: this.props.value}
     const contains = (str, list) => list.reduce((a, e) => a || str.includes(e), false)
+    console.log(this.props.placeholder)
     return (
       <div>
         {this.props.branches.length === 0 ? <div>Loading branches...</div>


### PR DESCRIPTION
… Chrome for Windows.

Fix an issue in which Google Chrome for Windows would sometimes not allow users to enable the extension when installed as a packed .crx file. This was done by adding update_url to the manifest-example.json file as described [here](https://productforums.google.com/forum/#!msg/chrome/kGgLwnrDKpQ/TFK1DG23BgAJ). The update_url can have any value, so there is no need to change it; leaving it as the default when creating manifest.json from the example should work fine.